### PR TITLE
#include<stdio.h> included to use printf

### DIFF
--- a/1er Cuatrimestre/Programacion de altas prestaciones/Lab1/main.cpp
+++ b/1er Cuatrimestre/Programacion de altas prestaciones/Lab1/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <stdio.h>
 #include <time.h>
 #include "Matriz.h"
 


### PR DESCRIPTION
May give error incompilation, add -std=gnu++11 argument to g++

$ g++ -o matriz *.cpp *.h -std=gnu++11